### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Talk to Jira
 
+<a href="https://glama.ai/mcp/servers/v7nmyscj80">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/v7nmyscj80/badge" alt="Jira Server MCP server" />
+</a>
+
 This is a TypeScript-based MCP server that provides tools to interact with Jira. It demonstrates core MCP concepts by providing:
 
 - Tools for executing JQL queries


### PR DESCRIPTION
This PR adds a badge for the [Jira MCP Server](https://glama.ai/mcp/servers/v7nmyscj80) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/v7nmyscj80">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/v7nmyscj80/badge" alt="Jira Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.